### PR TITLE
changed package URLs to https and ctan-package-overview

### DIFF
--- a/settings/packages.sty
+++ b/settings/packages.sty
@@ -39,21 +39,21 @@
 
 
 % Todo Notes
-% Dokumentation: http://ctan.mackichan.com/macros/latex/contrib/todonotes/todonotes.pdf
+% Dokumentation: https://www.ctan.org/pkg/todonotes
 \usepackage[ngerman, linecolor=orange, textsize=tiny, obeyFinal]{todonotes} 
 
 
 % Inhaltsverzeichnis Sektionen inkludieren
-% Dokumentation: http://vesta.informatik.rwth-aachen.de/ftp/pub/mirror/ctan/macros/latex/contrib/tocbibind/tocbibind.pdf
+% Dokumentation: https://www.ctan.org/pkg/tocbibind
 \usepackage[nottoc] % exludiert das inhaltsverzeichnis
 {tocbibind}
 
 % If Draft
-% Dokumentation: http://vesta.informatik.rwth-aachen.de/ftp/pub/mirror/ctan/macros/latex/contrib/oberdiek/ifdraft.pdf
+% Dokumentation: https://www.ctan.org/pkg/ifdraft
 \usepackage{ifdraft}
 
 % Typesetting theorems
-% Dokumentation: https://www.ctan.org/pkg/amsthm?lang=de
+% Dokumentation: https://www.ctan.org/pkg/amsthm
 \usepackage{amsthm} 
 
 % Bibliography


### PR DESCRIPTION
Instead of using direct links to each documentation via the generell mirror-redirect (http://mirrors.ctan.org/macros/latex/contrib/todonotes/todonotes.pdf) and instead of using a specific random mirror (like http://ctan.space-pro.be/tex-archive/macros/latex/contrib/todonotes/todonotes.pdf) I chose the generell package-page where the latest PDF of each package documentation is linked (https://www.ctan.org/pkg/todonotes).
For some packages there is even a documentation in a second language (next to the default English) available. And this website is available via HTTPS by default.