### PR TITLE
Sans serif fix for page numbers on pages from content/example.tex

### DIFF
--- a/settings/meta.sty
+++ b/settings/meta.sty
@@ -17,7 +17,7 @@
 \def\SecondReviewerFemale{0}
 
 \def\NeedDeclaration{1}
-\def\WithoutSerif{0}
+\def\WithoutSerif{1}
 
 % don't change
 
@@ -48,4 +48,5 @@
 \if\WithoutSerif1
 	\usepackage{helvet}
 	\renewcommand{\familydefault}{\sfdefault}
+	\fancyfoot[c]{\sffamily\thepage}
 \fi

--- a/settings/meta.sty
+++ b/settings/meta.sty
@@ -17,7 +17,7 @@
 \def\SecondReviewerFemale{0}
 
 \def\NeedDeclaration{1}
-\def\WithoutSerif{1}
+\def\WithoutSerif{0}
 
 % don't change
 


### PR DESCRIPTION
With the present switch named "WithOutSerif" a sans-serif font is applied to all text except for the page numbers of the content from the file "content/example.tex". With this fix these page numbers are now also displayed; this can be easily tested by copying more dummy text into "content/example.tex".