### PR TITLE
Alternative bibliography style

### DIFF
--- a/settings/packages.sty
+++ b/settings/packages.sty
@@ -62,9 +62,9 @@ backend=bibtex,
 style=alphabetic
 ]{biblatex}
 
-% Alternative bibliography style for more readability, e.g. (Smith / Wesson 1852) instead of [Smi52]
-% Please keep in mind that you need to comment the previous usepackage-command of biblatex (and its options) out, if you want to use this alternative bibliography style!
-% START of settings for alternative bibliography style
+%% Alternative bibliography style for more readability, e.g. (Smith / Wesson 1852) instead of [Smi52]
+%% Please keep in mind that you need to comment the previous usepackage-command of biblatex (and its options) out, if you want to use this alternative bibliography style!
+%% START of settings for alternative bibliography style
 %\usepackage[
 %backend=bibtex,
 %style=authoryear,
@@ -72,10 +72,10 @@ style=alphabetic
 %dashed=false
 %]{biblatex}
 %\DeclareNameAlias{sortname}{last-first}
-% END of settings for alternative bibliography style
-% OPTIONAL
-% increases the space between each entry of the bibliography,
-% especially recommended for the alternative bibliography style
+%% END of settings for alternative bibliography style
+%% OPTIONAL
+%% increases the space between each entry of the bibliography,
+%% especially recommended for the alternative bibliography style
 %\setlength\bibitemsep{\baselineskip}
 
 \usepackage{csquotes}

--- a/settings/packages.sty
+++ b/settings/packages.sty
@@ -62,6 +62,22 @@ backend=bibtex,
 style=alphabetic
 ]{biblatex}
 
+% Alternative bibliography style for more readability, e.g. (Smith / Wesson 1852) instead of [Smi52]
+% Please keep in mind that you need to comment the previous usepackage-command of biblatex (and its options) out, if you want to use this alternative bibliography style!
+% START of settings for alternative bibliography style
+%\usepackage[
+%backend=bibtex,
+%style=authoryear,
+%firstinits=true,
+%dashed=false
+%]{biblatex}
+%\DeclareNameAlias{sortname}{last-first}
+% END of settings for alternative bibliography style
+% OPTIONAL
+% increases the space between each entry of the bibliography,
+% especially recommended for the alternative bibliography style
+%\setlength\bibitemsep{\baselineskip}
+
 \usepackage{csquotes}
 
 \usepackage{color} %red, green, blue, yellow, cyan, magenta, black, white


### PR DESCRIPTION
After some work I was able to create a bibliography style that fits more into the guidelines of the template from Mrs. Kees (see Issue #4 ). It generates a citation and list of literature with a higher readability, e.g. for the standard command `\cite{}` it produces now "(Smith / Wesson 1852)" instead of "[SW52]".
In the bibliography the authors are listed each with their name and shortend surname, seperated by commas. Each attribute of the entry (title, publisher, ...) ends with a full stop. If an author-combination appear more than once in the list of literature (e.g. the same pair of authors publish more than once) their names will be displayed the second entry too - instead of a dash.

So far the new bibliography style has one downside: in contrast to the default bibliography style each entry in the list of literature is stuck right below its predecessor. I added an optional command especially for the new bibliography style to create some space between each entry with `\baselineskip`.

The alternative bibliography style is not active by default, but I added the required steps to use this bibliography style, e.g. to comment out the default usepackage-command of biblatex.

To be able to distinguish between inactive code and actual comments I added a second percent-symbol in front of each comment.